### PR TITLE
validation fix

### DIFF
--- a/routes/v1/users.js
+++ b/routes/v1/users.js
@@ -104,7 +104,7 @@ module.exports = function(/*middleware*/) {
 			});
 		})
 		.post(apiMiddleware.requireUser, function(req, res) {
-			if (parseInt(req.params.uid, 10) !== req.user.uid) {
+			if (parseInt(req.params.uid, 10) !== parseInt(req.user.uid)) {
 				return errorHandler.respond(401, res);
 			}
 


### PR DESCRIPTION
Currently you cannot use master token to auth and generate new token for a user. This is because source tries to compare 1 !== '1'

I suggest ensuring parsing in the other cases or parsing the field as soon as it gets populated.