### PR TITLE
Fix URL check on varying base-urls

### DIFF
--- a/routes/v2/middleware.js
+++ b/routes/v2/middleware.js
@@ -82,7 +82,7 @@ Middleware.requireUser = function(req, res, next) {
 				errorHandler.respond(401, res);
 			}
 		});
-	} else if ((routeMatch = req.originalUrl.match(/^\/api\/v\d+\/users\/(\d+)\/tokens$/)) && req.body.hasOwnProperty('password')) {
+	} else if ((routeMatch = req.originalUrl.match(/\/api\/v\d+\/users\/(\d+)\/tokens$/)) && req.body.hasOwnProperty('password')) {
 		// If token generation route is hit, check password instead
 		var uid = routeMatch[1];
 


### PR DESCRIPTION
The Problem:
When the forum base URL is something like `yourdomain.org/forum` instead of `forum.yourdomain.org` the check below always returns false even if the condition should be true.
This PR fixes this behaviour by simply not checking what the URL starts with.

I must admit I'm not entirely sure if this is 100% safe, might be possible to do something like `/api/different/route#/api/v2/users/1234/tokens` to get around this, but I couldn't really come up with a better idea for now.

/cc @djensen47