### PR TITLE
fix category privileges PUT issue when input single group or privilege

### DIFF
--- a/routes/v2/categories.js
+++ b/routes/v2/categories.js
@@ -73,12 +73,9 @@ module.exports = function(/*middleware*/) {
 		});
 
 	function changeGroupMembership(cid, privileges, groups, action, callback) {
-		if (!Array.isArray(privileges)) {
-			privileges = [privileges]
-		}
-		if (!Array.isArray(groups)) {
-			groups = [groups]
-		}
+		privileges = Array.isArray(privileges) ? privileges : [privileges];
+		groups = Array.isArray(groups) ? groups : [groups];
+
 		async.each(groups, function(group, groupCb) {
 			async.each(privileges, function(privilege, privilegeCb) {
 				Groups[action]('cid:' + cid + ':privileges:' + privilege, group, privilegeCb);

--- a/routes/v2/categories.js
+++ b/routes/v2/categories.js
@@ -73,6 +73,12 @@ module.exports = function(/*middleware*/) {
 		});
 
 	function changeGroupMembership(cid, privileges, groups, action, callback) {
+		if (!Array.isArray(privileges)) {
+			privileges = [privileges]
+		}
+		if (!Array.isArray(groups)) {
+			groups = [groups]
+		}
 		async.each(groups, function(group, groupCb) {
 			async.each(privileges, function(privilege, privilegeCb) {
 				Groups[action]('cid:' + cid + ':privileges:' + privilege, group, privilegeCb);


### PR DESCRIPTION
When call RESTful API v2 PUT /categories/:cid/privileges with single group or single privilege, the API will split the slug of group or name of privilege into characters and insert into corresponding privilege group. 