### PR TITLE
fix: jwt auth should not reset request body

### DIFF
--- a/routes/v2/middleware.js
+++ b/routes/v2/middleware.js
@@ -113,7 +113,6 @@ Middleware.requireUser = async function (req, res, next) {
 
 					req.uid = decoded._uid;
 					req.loggedIn = req.uid > 0;
-					req.body = decoded;
 					next();
 				});
 			} else {


### PR DESCRIPTION
It'd be great if req.body was not reset by auth middleware. Please let me know if ```decoded``` need to be kept as well.