### PR TITLE
Fix /util/upload race condition

### DIFF
--- a/routes/v2/util.js
+++ b/routes/v2/util.js
@@ -17,9 +17,9 @@ module.exports = function (/* middleware */) {
 			return next(new Error('[[error:uploads-are-disabled]]'));
 		}
 
-		uploadController.upload(req, res, function (uploadedFile, callback) {
-			uploadController.uploadFile(req.user.uid, uploadedFile, callback);
-		}, next);
+		await uploadController.upload(req, res, async function (uploadedFile) {
+			return await uploadController.uploadFile(req.user.uid, uploadedFile);
+        	});
 	});
 
 	app.route('/maintenance')


### PR DESCRIPTION
With NodeBB v1.15.x the /util/upload route does not work. All files saved by `multipart()` to temp directory are removed before they are used in a NodeBB's `src/controller/upload.js`. Also, `filesIterator` result is not returned into response body, because the iterator function does not return any value, it is just called.

This PR fixes file handling in a `/util/upload` route.