### PR TITLE
Corrected the name of the repo in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alternatively:
 
 ```
 $ cd /path/to/nodebb/node_modules
-$ git clone git@github.com:julianlam/nodebb-plugin-write-api.git
+$ git clone git@github.com:NodeBB/nodebb-plugin-write-api.git
 $ cd nodebb-plugin-write-api
 $ npm i
 ```


### PR DESCRIPTION
The readme had the old repo name in it, which means you can't follow the instructions to grab and install the plugin.